### PR TITLE
perf: optimize mesh and segmentation hot paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
 /docs/build/
+/benchmark/results*.json

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Ramiro Vignolo <ramirovignolo@gmail.com>"]
 version = "0.2.4"
 
 [deps]
-Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,7 +13,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
-Combinatorics = "1.0.3"
 Gridap = "0.19.11"
 IntervalSets = "0.7"
 LinearAlgebra = "1.9"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,19 @@ Build local docs with:
 julia --project=docs docs/make.jl
 ```
 
+## Benchmarks
+
+The benchmark suite uses BenchmarkTools and lives in `benchmark/`:
+
+```bash
+julia --project=benchmark benchmark/runbenchmarks.jl --quick
+julia --project=benchmark benchmark/runbenchmarks.jl
+julia --project=benchmark benchmark/runbenchmarks.jl --output benchmark/results.json
+```
+
+Benchmark definitions are grouped in `benchmark/benchmarks.jl` so they can also be loaded by
+PkgBenchmark-style workflows.
+
 ## License
 
 RayTracing.jl is distributed under the MIT License. See [LICENSE](LICENSE).

--- a/TODO
+++ b/TODO
@@ -1,4 +1,0 @@
-
-IDEAS:
-  1. mirar Meshes.jl y a la organizacion que pertenece. ver funciones de buscar in element, si las tiene
-  2. kdtrees para meshes: https://github.com/KristofferC/NearestNeighbors.jl

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,13 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
+RayTracing = "3007c720-8091-40db-9339-e09e4eb4c7ea"
+
+[compat]
+BenchmarkTools = "1"
+Gridap = "0.19.11"
+RayTracing = "0.2"
+julia = "1.10"
+
+[sources]
+RayTracing = {path = ".."}

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -76,7 +76,7 @@ end
 function element_volume_batch(mesh, cell_ids)
     s = 0.0
     @inbounds for cell_id in cell_ids
-        s += RayTracing.element_volume(mesh, mesh.cell_nodes[cell_id])
+        s += RayTracing.element_volume(mesh, cell_id)
     end
     return s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,177 @@
+using BenchmarkTools
+using Gridap
+using RayTracing
+
+const SUITE = BenchmarkGroup()
+
+const PINCELL_JSON = normpath(joinpath(@__DIR__, "..", "demo", "pincell.json"))
+const MODEL = DiscreteModelFromFile(PINCELL_JSON)
+const MESH = RayTracing.Mesh(MODEL)
+
+function make_generator(n_azim, spacing, bcs, volume_correction)
+    return TrackGenerator(MODEL, n_azim, spacing; bcs=bcs, volume_correction=volume_correction)
+end
+
+function traced_generator(n_azim, spacing, bcs, volume_correction)
+    tg = make_generator(n_azim, spacing, bcs, volume_correction)
+    trace!(tg)
+    return tg
+end
+
+function segmented_generator(n_azim, spacing, bcs, volume_correction)
+    tg = traced_generator(n_azim, spacing, bcs, volume_correction)
+    segmentize!(tg)
+    return tg
+end
+
+function first_track_segment(tg)
+    for track in tg.tracks_by_uid
+        isempty(track.segments) && continue
+        return track, first(track.segments)
+    end
+    error("No segmented tracks are available in the benchmark model.")
+end
+
+function point_batch(n)
+    return [RayTracing.Point2D(rand(), rand()) for _ in 1:n]
+end
+
+function shifted_point_batch(points)
+    return [p + RayTracing.Point2D(rand() + 1, rand() + 1) for p in points]
+end
+
+function line_batch(points_a, points_b)
+    return [
+        RayTracing.general_form(points_a[i], points_b[i])
+        for i in eachindex(points_a, points_b)
+    ]
+end
+
+function advance_step_batch(points, steps, ϕs)
+    s = 0.0
+    @inbounds for i in eachindex(points, steps, ϕs)
+        p = RayTracing.advance_step(points[i], steps[i], ϕs[i])
+        s += p[1] + p[2]
+    end
+    return s
+end
+
+function distance_batch(points_a, points_b)
+    s = 0.0
+    @inbounds for i in eachindex(points_a, points_b)
+        s += RayTracing.distance(points_a[i], points_b[i])
+    end
+    return s
+end
+
+function general_form_batch(points_a, points_b)
+    s = 0.0
+    @inbounds for i in eachindex(points_a, points_b)
+        ABC = RayTracing.general_form(points_a[i], points_b[i])
+        s += ABC[1] + ABC[2] + ABC[3]
+    end
+    return s
+end
+
+function element_volume_batch(mesh, cell_ids)
+    s = 0.0
+    @inbounds for cell_id in cell_ids
+        s += RayTracing.element_volume(mesh, mesh.cell_nodes[cell_id])
+    end
+    return s
+end
+
+function line_intersection_batch(lines_a, lines_b)
+    s = 0.0
+    @inbounds for i in eachindex(lines_a, lines_b)
+        parallel, point = RayTracing.intersection(lines_a[i], lines_b[i])
+        s += point[1] + point[2] + parallel
+    end
+    return s
+end
+
+const SAMPLE_TG = segmented_generator(8, 0.08, vacuum_boundaries(), false)
+const SAMPLE_TRACK_SEGMENT = first_track_segment(SAMPLE_TG)
+const SAMPLE_TRACK = SAMPLE_TRACK_SEGMENT[1]
+const SAMPLE_SEGMENT = SAMPLE_TRACK_SEGMENT[2]
+const SAMPLE_CELL = SAMPLE_SEGMENT.element
+const SAMPLE_POINT = RayTracing.midpoint(SAMPLE_SEGMENT.p, SAMPLE_SEGMENT.q)
+const BATCH_SIZE = 1024
+
+const MESH_REF = Ref(MESH)
+const SAMPLE_TRACK_REF = Ref(SAMPLE_TRACK)
+const SAMPLE_POINT_REF = Ref(SAMPLE_POINT)
+
+const GEOMETRY = SUITE["geometry"] = BenchmarkGroup()
+const POINTS = GEOMETRY["points"] = BenchmarkGroup()
+const MESHES = GEOMETRY["meshes"] = BenchmarkGroup()
+const INTERSECTIONS = GEOMETRY["intersections"] = BenchmarkGroup()
+
+POINTS["advance_step_batch"] = @benchmarkable advance_step_batch(points, steps, ϕs) setup=(
+    points = point_batch($BATCH_SIZE);
+    steps = rand($BATCH_SIZE);
+    ϕs = rand($BATCH_SIZE)
+)
+POINTS["distance_batch"] = @benchmarkable distance_batch(points_a, points_b) setup=(
+    points_a = point_batch($BATCH_SIZE);
+    points_b = point_batch($BATCH_SIZE)
+)
+POINTS["general_form_batch"] = @benchmarkable general_form_batch(points_a, points_b) setup=(
+    points_a = point_batch($BATCH_SIZE);
+    points_b = shifted_point_batch(points_a)
+)
+
+MESHES["construct"] = @benchmarkable RayTracing.Mesh($MODEL) evals=1
+MESHES["find_element"] = @benchmarkable RayTracing.find_element($(MESH_REF)[], $(SAMPLE_POINT_REF)[])
+MESHES["element_volume_batch"] = @benchmarkable element_volume_batch(mesh, cell_ids) setup=(
+    mesh = $(MESH_REF)[];
+    cell_ids = rand(1:length(mesh.cell_nodes), $BATCH_SIZE)
+)
+
+INTERSECTIONS["line_line_batch"] = @benchmarkable line_intersection_batch(lines_a, lines_b) setup=(
+    points_a = point_batch($BATCH_SIZE);
+    points_b = shifted_point_batch(points_a);
+    points_c = point_batch($BATCH_SIZE);
+    points_d = shifted_point_batch(points_c);
+    lines_a = line_batch(points_a, points_b);
+    lines_b = line_batch(points_c, points_d)
+)
+INTERSECTIONS["track_cell"] = @benchmarkable RayTracing.intersections(
+    $(MESH_REF)[], $SAMPLE_CELL, $(SAMPLE_TRACK_REF)[]
+)
+
+const WORKFLOWS = SUITE["workflows"] = BenchmarkGroup()
+const CASES = (
+    "coarse-vacuum" => (; n_azim=4, spacing=0.16, bcs=vacuum_boundaries(), volume_correction=false),
+    "moderate-vacuum" => (; n_azim=8, spacing=0.08, bcs=vacuum_boundaries(), volume_correction=false),
+    "moderate-reflective" => (; n_azim=8, spacing=0.08, bcs=reflective_boundaries(), volume_correction=false),
+    "moderate-periodic" => (; n_azim=8, spacing=0.08, bcs=periodic_boundaries(), volume_correction=false),
+    "volume-correction" => (; n_azim=8, spacing=0.08, bcs=vacuum_boundaries(), volume_correction=true),
+)
+
+for (name, case) in CASES
+    group = WORKFLOWS[name] = BenchmarkGroup()
+    n_azim = case.n_azim
+    spacing = case.spacing
+    bcs = case.bcs
+    volume_correction = case.volume_correction
+
+    group["construct"] = @benchmarkable make_generator(
+        $n_azim, $spacing, $bcs, $volume_correction
+    ) evals=1
+
+    group["trace!"] = @benchmarkable trace!(tg) setup=(
+        tg = make_generator($n_azim, $spacing, $bcs, $volume_correction)
+    ) evals=1
+
+    group["segmentize!"] = @benchmarkable segmentize!(tg) setup=(
+        tg = traced_generator($n_azim, $spacing, $bcs, $volume_correction)
+    ) evals=1
+
+    group["trace+segmentize!"] = @benchmarkable begin
+        trace!(tg)
+        segmentize!(tg)
+    end setup=(
+        tg = make_generator($n_azim, $spacing, $bcs, $volume_correction)
+    ) evals=1
+end

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -1,0 +1,91 @@
+using BenchmarkTools
+
+include("benchmarks.jl")
+
+function usage()
+    return """
+    Usage:
+      julia --project=benchmark benchmark/runbenchmarks.jl [options]
+
+    Options:
+      --quick             Run each benchmark for 1 second.
+      --seconds <value>   Run each benchmark for the given number of seconds.
+      --output <path>     Save results as BenchmarkTools JSON.
+      --list              Print benchmark names without running them.
+      -h, --help          Show this message.
+    """
+end
+
+function benchmark_names(group::BenchmarkGroup, prefix=String[])
+    names = String[]
+    for key in sort(collect(keys(group)); by=string)
+        value = group[key]
+        path = [prefix; string(key)]
+        if value isa BenchmarkGroup
+            append!(names, benchmark_names(value, path))
+        else
+            push!(names, join(path, " / "))
+        end
+    end
+    return names
+end
+
+function parse_args(args)
+    seconds = 5.0
+    output = nothing
+    list_only = false
+
+    i = 1
+    while i <= length(args)
+        arg = args[i]
+
+        if arg == "--quick"
+            seconds = 1.0
+        elseif arg == "--seconds"
+            i == length(args) && error("Missing value after --seconds.")
+            i += 1
+            seconds = parse(Float64, args[i])
+        elseif startswith(arg, "--seconds=")
+            seconds = parse(Float64, split(arg, "=", limit=2)[2])
+        elseif arg == "--output"
+            i == length(args) && error("Missing value after --output.")
+            i += 1
+            output = args[i]
+        elseif startswith(arg, "--output=")
+            output = split(arg, "=", limit=2)[2]
+        elseif arg == "--list"
+            list_only = true
+        elseif arg in ("-h", "--help")
+            print(usage())
+            exit(0)
+        else
+            error("Unknown argument: $arg")
+        end
+
+        i += 1
+    end
+
+    seconds > 0 || error("--seconds must be positive.")
+    return (; seconds, output, list_only)
+end
+
+function main(args=ARGS)
+    options = parse_args(args)
+
+    if options.list_only
+        println(join(benchmark_names(SUITE), "\n"))
+        return nothing
+    end
+
+    results = run(SUITE; seconds=options.seconds, verbose=true)
+    display(results)
+
+    if options.output !== nothing
+        BenchmarkTools.save(options.output, results)
+        println("Saved benchmark results to $(options.output)")
+    end
+
+    return results
+end
+
+main()

--- a/demo/makie.jl
+++ b/demo/makie.jl
@@ -8,7 +8,7 @@ using UnPack
 const TAIL_LENGTH = 20000
 const BACKGROUND_COLOR = RGBf(0.98, 0.98, 0.98);
 
-# Transport problem
+# Transport problem.
 jsonfile = joinpath(@__DIR__, "pincell.json")
 model = DiscreteModelFromFile(jsonfile)
 nφ = 16
@@ -19,7 +19,7 @@ tg = TrackGenerator(model, nφ, δ, bcs=bcs)
 trace!(tg)
 segmentize!(tg)
 
-# Lightweight mesh drawing function
+# Draw a lightweight mesh.
 function draw_lightweight_mesh!(ax, mesh;
     cell_color=RGBf(0.95, 0.95, 0.95),
     edge_color=RGBf(0.8, 0.8, 0.8),
@@ -32,23 +32,23 @@ function draw_lightweight_mesh!(ax, mesh;
     face_labeling = get_face_labeling(model)
     cell_tags = Gridap.Geometry.get_face_tag(face_labeling, 2)
 
-    # Pre-allocate arrays to avoid repeated allocations
+    # Preallocate arrays to avoid repeated allocations.
     cell_count = length(cell_nodes)
     cell_colors = Vector{RGBf}(undef, cell_count)
     all_polygons = Vector{Vector{Point2f}}(undef, cell_count)
 
-    # Prepare all polygon coordinates in a single pass
+    # Prepare all polygon coordinates in a single pass.
     for (cell_id, node_ids) in enumerate(cell_nodes)
         nodes = [node_coordinates[nid] for nid in node_ids]
         all_polygons[cell_id] = Point2f.(getproperty.(nodes, :data))
 
-        # color based on cell type, darker for increasing cell type
+        # Color by cell type, darkening higher tags.
         cell_tag = cell_tags[cell_id]
         cell_color′ = cell_color * (cell_tag / maximum(cell_tags))
         cell_colors[cell_id] = cell_color′
     end
 
-    # Draw all polygons in a single batch operation
+    # Draw all polygons in a single batch operation.
     poly!(ax, all_polygons,
         color=cell_colors,
         strokecolor=edge_color,
@@ -56,7 +56,7 @@ function draw_lightweight_mesh!(ax, mesh;
         alpha=alpha)
 end
 
-# updates the trajectory with a new segment
+# Update the trajectory with a new segment.
 function update_ray!(trajectory_obs, segment, direction)
     if direction == RayTracing.Forward
         start_point = Point2f(segment.p)
@@ -66,25 +66,25 @@ function update_ray!(trajectory_obs, segment, direction)
         end_point = Point2f(segment.p)
     end
 
-    # add new points to the end of the trajectory
+    # Add new points to the end of the trajectory.
     push!(trajectory_obs[], start_point)
     push!(trajectory_obs[], end_point)
 end
 
-# plots a cyclic trajectory with enhanced colors, output can be gif or even mp4
+# Plot a cyclic trajectory; output can be a GIF or an MP4.
 function trajectory(fig, ax, initial_track, initial_direction, output)
 
-    # initialize track and direction
+    # Initialize the track and direction.
     track = initial_track
     dir = initial_direction
 
-    # a circular buffer maintains its size and pushed values replace the latest one
+    # A circular buffer keeps a fixed tail length as new values are pushed.
     x1, y1 = track.p
     trajectory = CircularBuffer{Point2f}(TAIL_LENGTH)
     fill!(trajectory, Point2f(x1, y1))
     trajectory_obs = Observable(trajectory)
 
-    # Draw the trajectory with enhanced styling
+    # Draw the trajectory.
     lines!(ax, trajectory_obs;
         linewidth=2.5,
         color=to_color(:black),
@@ -92,37 +92,37 @@ function trajectory(fig, ax, initial_track, initial_direction, output)
 
     record(fig, output, framerate=60) do io
 
-        # Only update observable every N segments, for performance reasons
+        # Only update the observable every N segments for performance.
         update_counter = 0
         update_frequency = 5
 
         while true
 
-            # the segments are stored in reverse order for backward tracks
+            # Segments are stored in reverse order for backward tracks.
             segments = dir == RayTracing.Backward ? reverse(track.segments) : track.segments
 
-            # for each segment, update the trajectory and record the frame
+            # Update the trajectory and record one frame per segment.
             for (i, segment) in enumerate(segments)
 
                 update_ray!(trajectory_obs, segment, dir)
                 update_counter += 1
 
-                # Only update the observable periodically to reduce overhead
+                # Update the observable periodically to reduce overhead.
                 if update_counter % update_frequency == 0
                     trajectory_obs[] = trajectory_obs[]
                 end
 
-                # record all segments, but we could record only if a condition was met (e.g every 10 segments)
+                # Record every segment; this could be throttled, for example every 10 segments.
                 recordframe!(io)
             end
 
-            # Force final update
+            # Force a final update.
             trajectory_obs[] = trajectory_obs[]
 
-            # to separate tracks into segments
+            # Separate tracks in the rendered trajectory.
             push!(trajectory_obs[], Point2f(NaN, NaN))
 
-            # update the track and direction
+            # Update the track and direction.
             if dir == RayTracing.Forward
                 dir = RayTracing.dir_next_track_fwd(track)
                 track = track.next_track_fwd
@@ -131,7 +131,7 @@ function trajectory(fig, ax, initial_track, initial_direction, output)
                 track = track.next_track_bwd
             end
 
-            # stop the animation when the track returns to the initial track
+            # Stop when the trajectory returns to the initial track.
             track.uid != initial_track.uid || break
         end
     end
@@ -144,7 +144,7 @@ fig = Figure(
     font="Computer Modern",
 )
 
-# Create main axis with enhanced styling
+# Create the main axis.
 ax = Axis(
     fig[1, 1],
     title="Ray Tracing Visualization",
@@ -169,18 +169,18 @@ ax = Axis(
     limits=(nothing, nothing, nothing, nothing)
 )
 
-# Set axis limits
+# Set axis limits.
 GLMakie.xlims!(ax, (tg.mesh.bb_min.x, tg.mesh.bb_max.x))
 GLMakie.ylims!(ax, (tg.mesh.bb_min.y, tg.mesh.bb_max.y))
 
-# Draw lightweight mesh
+# Draw the lightweight mesh.
 draw_lightweight_mesh!(ax, tg.mesh)
 
-# Plot a single track, purposefully selected to look nice
+# Plot one track selected for a clear visualization.
 initial_track = tg.tracks[2][1]
 trajectory(fig, ax, initial_track, RayTracing.Forward, joinpath(@__DIR__, "cyclic_track_with_mesh.gif"))
 
-# This also works and would plot all tracks simultaneously, but it has limited performance
+# This also plots all tracks simultaneously, but performance is poor.
 # for (i, azimuthal_tracks) in enumerate(tg.tracks)
 #     @async trajectory(ax, first(azimuthal_tracks), RayTracing.Forward, "cyclic_track.gif")
 # end

--- a/demo/pincell-gmsh.jl
+++ b/demo/pincell-gmsh.jl
@@ -7,40 +7,40 @@ gmsh.model.add("pincell")
 
 factory = gmsh.model.geo
 
-# in cm
-p = 1.6        # pitch
+# Dimensions in cm.
+p = 1.6        # Pitch.
 p_2 = p / 2
-ri = 0.5       # internal radius
-t = 0.1        # wall thickness
-ro = ri + t    # external radius
+ri = 0.5       # Inner radius.
+t = 0.1        # Wall thickness.
+ro = ri + t    # Outer radius.
 
 lc = 4e-2
 
-# inner circle
-factory.addPoint(p_2, p_2, 0, lc, 1)       # center
-factory.addPoint(p_2 + ri, p_2, 0, lc, 2)  # right
-factory.addPoint(p_2, p_2 + ri, 0, lc, 3)  # up
-factory.addPoint(p_2 - ri, p_2, 0, lc, 4)  # left
-factory.addPoint(p_2, p_2 - ri, 0, lc, 5)  # down
+# Inner circle.
+factory.addPoint(p_2, p_2, 0, lc, 1)       # Center.
+factory.addPoint(p_2 + ri, p_2, 0, lc, 2)  # Right.
+factory.addPoint(p_2, p_2 + ri, 0, lc, 3)  # Up.
+factory.addPoint(p_2 - ri, p_2, 0, lc, 4)  # Left.
+factory.addPoint(p_2, p_2 - ri, 0, lc, 5)  # Down.
 factory.addCircleArc(2, 1, 3, 1)
 factory.addCircleArc(3, 1, 4, 2)
 factory.addCircleArc(4, 1, 5, 3)
 factory.addCircleArc(5, 1, 2, 4)
 factory.addCurveLoop([1, 2, 3, 4], 1)
 
-# outer circle
-# factory.addPoint(p_2, p_2, 0, lc, 1)     # center
-factory.addPoint(p_2 + ro, p_2, 0, lc, 6)  # right
-factory.addPoint(p_2, p_2 + ro, 0, lc, 7)  # up
-factory.addPoint(p_2 - ro, p_2, 0, lc, 8)  # left
-factory.addPoint(p_2, p_2 - ro, 0, lc, 9)  # down
+# Outer circle.
+# factory.addPoint(p_2, p_2, 0, lc, 1)     # Center.
+factory.addPoint(p_2 + ro, p_2, 0, lc, 6)  # Right.
+factory.addPoint(p_2, p_2 + ro, 0, lc, 7)  # Up.
+factory.addPoint(p_2 - ro, p_2, 0, lc, 8)  # Left.
+factory.addPoint(p_2, p_2 - ro, 0, lc, 9)  # Down.
 factory.addCircleArc(6, 1, 7, 5)
 factory.addCircleArc(7, 1, 8, 6)
 factory.addCircleArc(8, 1, 9, 7)
 factory.addCircleArc(9, 1, 6, 8)
 factory.addCurveLoop([5, 6, 7, 8], 2)
 
-# square cell
+# Square cell.
 factory.addPoint(0, 0, 0, lc, 10)
 factory.addPoint(p, 0, 0, lc, 11)
 factory.addPoint(p, p, 0, lc, 12)
@@ -52,10 +52,10 @@ factory.addLine(13, 10, 12)
 factory.addCurveLoop([9, 10, 11, 12], 3)
 
 factory.addPlaneSurface([1], 1)
-factory.addPlaneSurface([2, 1], 2) # le agrego el hole `1` (no estoy teniendo en cuenta nada de sentidos de giro, no se si hay que hacerlo)
+factory.addPlaneSurface([2, 1], 2) # Add loop `1` as a hole; orientation is not handled here.
 factory.addPlaneSurface([3, 2, 1], 3)
 
-# materials
+# Materials.
 factory.addPhysicalGroup(2, [1], 1)
 factory.addPhysicalGroup(2, [2], 2)
 factory.addPhysicalGroup(2, [3], 3)
@@ -63,7 +63,7 @@ GridapGmsh.gmsh.model.setPhysicalName(2, 1, "pin")
 GridapGmsh.gmsh.model.setPhysicalName(2, 2, "cladding")
 GridapGmsh.gmsh.model.setPhysicalName(2, 3, "water")
 
-# boundaries
+# Boundaries.
 factory.addPhysicalGroup(1,  [9], 4)
 factory.addPhysicalGroup(1, [10], 5)
 factory.addPhysicalGroup(1, [11], 6)
@@ -87,6 +87,6 @@ end
 
 gmsh.finalize()
 
-# move to json file format
+# Convert the mesh to Gridap's JSON format.
 model = GmshDiscreteModel(mshfile; renumber=true)
 Gridap.Io.to_json_file(model, jsonfile)

--- a/src/RayTracing.jl
+++ b/src/RayTracing.jl
@@ -4,7 +4,6 @@ using UnPack
 using RecipesBase
 using StaticArrays
 using IntervalSets
-using Combinatorics
 using LinearAlgebra
 using NearestNeighbors
 using Gridap: VectorValue, num_cells, get_grid

--- a/src/azimuthal_quad.jl
+++ b/src/azimuthal_quad.jl
@@ -28,8 +28,7 @@ The azimuthal quadrature organizes angles into a symmetric structure:
 - **First quadrant**: [0, π/2) with N4 angles
 - **Second quadrant**: [π/2, π) with N4 angles
 
-Angles in (π, 2π) are avoided because of the symmetry of the problem. This helps reducing
-the computational cost.
+Angles in (π, 2π) are avoided because of problem symmetry. This reduces computational cost.
 
 ## Usage
 
@@ -59,8 +58,8 @@ supp_idx = supplementary_azimuthal_idx(aq, 1)  # 4
 The weights `ωₐ` are computed to ensure proper numerical integration:
 
 ```julia
-# Sum of weights should integrate to unity
-sum(aq.ωₐ) ≈ 0.5  # Over half-plane (0, π)
+# The sum of weights should integrate to unity.
+sum(aq.ωₐ) ≈ 0.5  # Over the half-plane (0, π).
 ```
 
 ## Notes

--- a/src/intersection.jl
+++ b/src/intersection.jl
@@ -9,6 +9,15 @@ The expected number of intersections.
 """
 const EXPECTED_INTERSECTIONS = 2
 
+@inline function _intersection_point(
+    i::Int, p1::Point2D{T}, p2::Point2D{T}, p3::Point2D{T}, p4::Point2D{T}
+) where {T}
+    i == 1 && return p1
+    i == 2 && return p2
+    i == 3 && return p3
+    return p4
+end
+
 """
     general_form(xi::Point2D, xo::Point2D)
 
@@ -150,10 +159,13 @@ function intersections(
 
     length(cell_node_ids) >= 3 || throw(ArgumentError("Element must have at least 3 nodes"))
 
-    intersection_points = MVector{MAX_INTERSECTIONS,Point2D{T}}(undef)
-
     # The number of intersections determines how the element crossing should be handled.
     num_intersections = 0
+    zero_point = Point2D{T}(0, 0)
+    intersection_1 = zero_point
+    intersection_2 = zero_point
+    intersection_3 = zero_point
+    intersection_4 = zero_point
 
     for edge_idx in eachindex(cell_node_ids)
 
@@ -182,7 +194,18 @@ function intersections(
         else
             # Otherwise, this is a valid intersection.
             num_intersections += 1
-            intersection_points[num_intersections] = x_int
+            if num_intersections == 1
+                intersection_1 = x_int
+            elseif num_intersections == 2
+                intersection_2 = x_int
+            elseif num_intersections == 3
+                intersection_3 = x_int
+            elseif num_intersections == 4
+                intersection_4 = x_int
+            else
+                @warn "Unexpected number of intersections: $num_intersections"
+                return zero_point, zero_point
+            end
         end
     end
 
@@ -191,21 +214,27 @@ function intersections(
         # Vertex intersections can create extra points; keep the farthest pair.
         ℓ = zero(T)
         p = q = u = v = Point2D{T}(0, 0)
-        for (i, j) in combinations(1:num_intersections, 2)
-            u = intersection_points[i]
-            v = intersection_points[j]
-            ℓi = norm(u - v)
-            if ℓi > ℓ
-                p = u
-                q = v
-                ℓ = ℓi
+        for i in 1:(num_intersections-1)
+            u = _intersection_point(
+                i, intersection_1, intersection_2, intersection_3, intersection_4
+            )
+            for j in (i+1):num_intersections
+                v = _intersection_point(
+                    j, intersection_1, intersection_2, intersection_3, intersection_4
+                )
+                ℓi = norm(u - v)
+                if ℓi > ℓ
+                    p = u
+                    q = v
+                    ℓ = ℓi
+                end
             end
         end
         return order_intersection_points(track, p, q)
 
     elseif isequal(num_intersections, EXPECTED_INTERSECTIONS)
 
-        p, q = intersection_points
+        p, q = intersection_1, intersection_2
 
         if isapprox(p, q)
             # The track hits a vertex; return the point itself so the caller can step forward.

--- a/src/intersection.jl
+++ b/src/intersection.jl
@@ -152,21 +152,21 @@ function intersections(
 
     intersection_points = MVector{MAX_INTERSECTIONS,Point2D{T}}(undef)
 
-    # Based on the number of intersections, we can determine the type of intersection
+    # The number of intersections determines how the element crossing should be handled.
     num_intersections = 0
 
     for edge_idx in eachindex(cell_node_ids)
 
         next_edge_idx = edge_idx == lastindex(cell_node_ids) ? 1 : edge_idx + 1
 
-        # Get node coordinates and cast them to Point2D
+        # Get node coordinates and cast them to Point2D.
         p1 = convert(Point2D{T}, node_coordinates[cell_node_ids[edge_idx]])
         p2 = convert(Point2D{T}, node_coordinates[cell_node_ids[next_edge_idx]])
 
-        # Compute general form equation for the selected element face
+        # Compute the general-form equation for the selected element edge.
         ABC = general_form(p1, p2)
 
-        # Compute intersections between track and element face
+        # Compute the intersection between the track and the element edge.
         parallel, x_int = intersection(track.ABC, ABC)
 
         if parallel
@@ -180,7 +180,7 @@ function intersections(
             continue
 
         else
-            # Otherwise, this is a valid intersection
+            # Otherwise, this is a valid intersection.
             num_intersections += 1
             intersection_points[num_intersections] = x_int
         end
@@ -188,8 +188,7 @@ function intersections(
 
     if num_intersections in (MAX_INTERSECTIONS - 1, MAX_INTERSECTIONS)
 
-        # There are intersections at the vertices, we need to find the two points that are
-        # the farthest apart.
+        # Vertex intersections can create extra points; keep the farthest pair.
         ℓ = zero(T)
         p = q = u = v = Point2D{T}(0, 0)
         for (i, j) in combinations(1:num_intersections, 2)
@@ -209,19 +208,17 @@ function intersections(
         p, q = intersection_points
 
         if isapprox(p, q)
-            # We are on vertex, return the point itself and the parent function will move
-            # a tiny step forward
+            # The track hits a vertex; return the point itself so the caller can step forward.
             return p, q
         else
             return order_intersection_points(track, p, q)
         end
 
     elseif iszero(num_intersections) || isone(num_intersections)
-        # The parent function needs to handle this case, probably by moving a tiny step
-        # forward
+        # The caller handles this by moving a tiny step forward.
         return Point2D{T}(0, 0), Point2D{T}(0, 0)
     else
-        # This should never happen with a convex polygon, but handle gracefully
+        # This should never happen with a convex polygon, but handle it defensively.
         @warn "Unexpected number of intersections: $num_intersections"
         return Point2D{T}(0, 0), Point2D{T}(0, 0)
     end

--- a/src/intersection.jl
+++ b/src/intersection.jl
@@ -145,8 +145,7 @@ function intersections(
     cell_id <= length(mesh.ordered_cell_nodes) ||
         throw(ArgumentError("Cell ID out of range: $cell_id"))
 
-    @unpack model, ordered_cell_nodes = mesh
-    node_coordinates = get_node_coordinates(get_grid(model))
+    @unpack node_coordinates, ordered_cell_nodes = mesh
     cell_node_ids = ordered_cell_nodes[cell_id]
 
     length(cell_node_ids) >= 3 || throw(ArgumentError("Element must have at least 3 nodes"))

--- a/src/intersection.jl
+++ b/src/intersection.jl
@@ -142,11 +142,12 @@ function intersections(
 ) where {BCFwd,BCBwd,DFwd,DBwd,T}
 
     cell_id > 0 || throw(ArgumentError("Cell ID must be positive, got: $cell_id"))
-    cell_id <= length(mesh.cell_nodes) || throw(ArgumentError("Cell ID out of range: $cell_id"))
+    cell_id <= length(mesh.ordered_cell_nodes) ||
+        throw(ArgumentError("Cell ID out of range: $cell_id"))
 
-    @unpack model, cell_nodes = mesh
+    @unpack model, ordered_cell_nodes = mesh
     node_coordinates = get_node_coordinates(get_grid(model))
-    cell_node_ids = ordered_node_ids(mesh, cell_nodes[cell_id])
+    cell_node_ids = ordered_cell_nodes[cell_id]
 
     length(cell_node_ids) >= 3 || throw(ArgumentError("Element must have at least 3 nodes"))
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -52,7 +52,7 @@ ray tracing pipeline for:
 ## Example
 
 ```julia
-# Create a mesh from a geometric model from Gridap
+# Create a mesh from a Gridap geometric model.
 model = DiscreteModelFromFile(jsonfile)
 mesh = Mesh(model)
 
@@ -113,7 +113,7 @@ Returns the width of the rectangular mesh.
 @inline width(mesh::Mesh) = mesh.bb_max[1] - mesh.bb_min[1]
 
 """
-    width(mesh::Mesh)
+    height(mesh::Mesh)
 
 Returns the height of the rectangular mesh.
 """
@@ -239,7 +239,7 @@ end
 """
     point_in_element(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Point2D) -> Bool
 
-Checks if a given point `x` lies inside the element defined by the node coordinates ids
+Checks if a given point `x` lies inside the element defined by the node coordinate IDs
 `node_ids`.
 """
 function point_in_element(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Point2D)
@@ -273,7 +273,7 @@ end
 """
     point_in_element(mesh::Mesh, _::Val{3}, node_ids::AbstractVector{<:Int32}, x::Point2D) -> Bool
 
-Checks if a given point `x` lies inside the triangle defined by the node coordinates ids
+Checks if a given point `x` lies inside the triangle defined by the node coordinate IDs
 `node_ids`.
 """
 @inline point_in_element(mesh::Mesh, _::Val{3}, node_ids::AbstractVector{<:Int32}, x::Point2D) =
@@ -282,7 +282,7 @@ Checks if a given point `x` lies inside the triangle defined by the node coordin
 """
     point_in_element(mesh::Mesh, _::Val{4}, node_ids::AbstractVector{<:Int32}, x::Point2D) -> Bool
 
-Checks if a given point `x` lies inside the quadrangle defined by the node coordinates ids
+Checks if a given point `x` lies inside the quadrangle defined by the node coordinate IDs
 `node_ids`.
 """
 @inline point_in_element(mesh::Mesh, _::Val{4}, node_ids::AbstractVector{<:Int32}, x::Point2D) =
@@ -352,7 +352,7 @@ The function employs a two-stage search strategy:
 ## Usage Examples
 
 ```julia
-# Find which element contains a specific point
+# Find the element containing a specific point.
 point = Point2D(1.5, 2.3)
 element_id = find_element(mesh, point)
 
@@ -389,21 +389,21 @@ element_id = find_element(mesh, point, k=5)
 function find_element(mesh::Mesh, x::Point2D, k::Int=2)
     @unpack model, kdtree, node_cells = mesh
 
-    # get the nearest node id closest to `x`
+    # Find the nearest node to `x`.
     nn_id, _ = nn(kdtree, x)
 
-    # get the associated cell ids that contain the nearest node
+    # Get the cell IDs associated with the nearest node.
     cell_ids = node_cells[nn_id]
 
-    # define the invalid element id
+    # Define the invalid element ID.
     invalid_element_id = -one(eltype(cell_ids))
 
-    # loop over those cells until the element containing `x` is found
+    # Search those cells for the element containing `x`.
     element = _find_element_in_cells(mesh, cell_ids, x)
     element != invalid_element_id && return element
 
-    # the mesh might be deformed, i.e. the cells that contain the nearest node do not
-    # contain the point `x`. In that case, we need to search for more nodes.
+    # In a deformed mesh, the cells attached to the nearest node may not contain `x`;
+    # search additional nearby nodes in that case.
     nn_ids, _ = knn(kdtree, x, k, true, i -> isequal(i, nn_id)) # TODO: cache!
     for node_id in nn_ids
         cell_ids = node_cells[node_id]
@@ -500,12 +500,13 @@ function point_in_triangle(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Poi
     r = @SVector [x[1], x[2], 1]
     λ = R \ r
 
-    # return true if it lies in or on the triangle
+    # Return true if `x` lies inside or on the triangle.
     T = eltype(λ)
     tol = sqrt(eps(T))
     domain = ClosedInterval{T}(zero(T) - tol, one(T) + tol)
     return λ[1] in domain && λ[2] in domain && λ[3] in domain
-    # return all(in.(λ, Ref(domain))) # allocates
+    # Equivalent, but allocates:
+    # return all(in.(λ, Ref(domain)))
 end
 
 """
@@ -609,11 +610,11 @@ Collectively cover the quadrangle: Q = T₁ ∪ T₂ ∪ T₃ ∪ T₄
 """
 function point_in_quadrangle(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Point2D)
 
-    # triangle node ids
+    # Triangle node IDs.
     t_node_ids = MVector{3,eltype(node_ids)}(undef)
     ordered_ids = ordered_node_ids(mesh, node_ids)
 
-    # look on 4 triangles because we do not know the order of the nodes
+    # Test four triangles because node ordering may vary.
     for i in 1:4
         for j in 1:3
             k = mod1(i + j - 1, 4) # k = (i + j - 2) % 4 + 1, k = mod(i + j - 1, 1:4)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -17,9 +17,10 @@ for ray tracing algorithms in neutron transport simulations.
 - `model::M`: The underlying geometric model containing mesh topology and properties
 - `kdtree::K`: Spatial index structure for efficient nearest-neighbor searches and spatial
   queries
-- `node_cells::N`: Mapping from node indices to the set of cells containing each node
-- `cell_nodes::C`: Mapping from cell indices to the ordered list of node indices defining
-  each cell
+- `node_cells::N`: Materialized mapping from node indices to the set of cells containing
+  each node
+- `cell_nodes::C`: Materialized mapping from cell indices to the ordered list of node
+  indices defining each cell
 - `bb_min::B`: Minimum coordinates of the mesh bounding box (lower-left corner)
 - `bb_max::B`: Maximum coordinates of the mesh bounding box (upper-right corner)
 
@@ -141,10 +142,16 @@ mesh operations:
 function Mesh(model::UnstructuredDiscreteModel)
     grid = get_grid(model)
     kdtree = KDTree(grid)
-    node_cells = get_faces(get_grid_topology(model), 0, num_cell_dims(model))
-    cell_nodes = get_cell_node_ids(grid)
+    node_cells = materialize_connectivity(
+        get_faces(get_grid_topology(model), 0, num_cell_dims(model))
+    )
+    cell_nodes = materialize_connectivity(get_cell_node_ids(grid))
     bb_min, bb_max = bounding_box(grid)
     return Mesh(model, kdtree, node_cells, cell_nodes, bb_min, bb_max)
+end
+
+function materialize_connectivity(connectivity)
+    return [Vector{Int32}(ids) for ids in connectivity]
 end
 
 """

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -9,27 +9,29 @@ for ray tracing algorithms in neutron transport simulations.
 - `M`: Type of the underlying geometric model
 - `K`: Type of the spatial index structure (typically a KD-tree)
 - `NC`: Type of the materialized connectivity mappings
-- `T`: Type of the bounding box coordinates
+- `T`: Type of the mesh coordinates
 
 ## Fields
 
 - `model::M`: The underlying geometric model containing mesh topology and properties
+- `node_coordinates::Vector{Point2D{T}}`: Materialized node coordinates used by geometric
+  kernels
 - `kdtree::K`: Spatial index structure for efficient nearest-neighbor searches and spatial
   queries
-- `node_cells::N`: Materialized mapping from node indices to the set of cells containing
+- `node_cells::NC`: Materialized mapping from node indices to the set of cells containing
   each node
-- `cell_nodes::C`: Materialized mapping from cell indices to the node indices defining each
+- `cell_nodes::NC`: Materialized mapping from cell indices to the node indices defining each
   cell
-- `ordered_cell_nodes::C`: Cell-node mapping ordered geometrically around each cell
-- `bb_min::B`: Minimum coordinates of the mesh bounding box (lower-left corner)
-- `bb_max::B`: Maximum coordinates of the mesh bounding box (upper-right corner)
+- `ordered_cell_nodes::NC`: Cell-node mapping ordered geometrically around each cell
+- `bb_min::Point2D{T}`: Minimum coordinates of the mesh bounding box (lower-left corner)
+- `bb_max::Point2D{T}`: Maximum coordinates of the mesh bounding box (upper-right corner)
 
 ## Purpose
 
 This structure serves as the primary data container for mesh-based ray tracing algorithms,
 providing:
 
-1. **Geometric Information**: Node coordinates and cell definitions through the model
+1. **Geometric Information**: Cached node coordinates and cell definitions
 2. **Topological Relationships**: Efficient lookups between nodes and cells
 3. **Spatial Indexing**: Fast spatial queries using the KD-tree
 4. **Bounding Information**: Global mesh bounds for optimization and validation
@@ -78,6 +80,7 @@ in_bounds = all(mesh.bb_min .≤ point .≤ mesh.bb_max)
 """
 struct Mesh{M<:UnstructuredDiscreteModel,K<:KDTree,NC,T}
     model::M
+    node_coordinates::Vector{Point2D{T}}
     kdtree::K
     node_cells::NC
     cell_nodes::NC
@@ -142,22 +145,29 @@ mesh operations:
 """
 function Mesh(model::UnstructuredDiscreteModel)
     grid = get_grid(model)
-    kdtree = KDTree(grid)
+    node_coordinates = materialize_node_coordinates(grid)
+    kdtree = KDTree(node_coordinates)
     node_cells = materialize_connectivity(
         get_faces(get_grid_topology(model), 0, num_cell_dims(model))
     )
     cell_nodes = materialize_connectivity(get_cell_node_ids(grid))
-    ordered_cell_nodes = materialize_ordered_cell_nodes(grid, cell_nodes)
-    bb_min, bb_max = bounding_box(grid)
-    return Mesh(model, kdtree, node_cells, cell_nodes, ordered_cell_nodes, bb_min, bb_max)
+    ordered_cell_nodes = materialize_ordered_cell_nodes(node_coordinates, cell_nodes)
+    bb_min, bb_max = bounding_box(node_coordinates)
+    return Mesh(
+        model, node_coordinates, kdtree, node_cells, cell_nodes, ordered_cell_nodes,
+        bb_min, bb_max
+    )
+end
+
+function materialize_node_coordinates(grid::UnstructuredGrid{Dc,Dp,Tp}) where {Dc,Dp,Tp}
+    return convert.(Point2D{Tp}, get_node_coordinates(grid))
 end
 
 function materialize_connectivity(connectivity)
     return [Vector{Int32}(ids) for ids in connectivity]
 end
 
-function materialize_ordered_cell_nodes(grid, cell_nodes)
-    node_coordinates = get_node_coordinates(grid)
+function materialize_ordered_cell_nodes(node_coordinates, cell_nodes)
     return [Vector{Int32}(ordered_node_ids(node_coordinates, node_ids)) for node_ids in cell_nodes]
 end
 
@@ -183,6 +193,12 @@ function KDTree(grid::UnstructuredGrid{Dc,Dp,Tp}) where {Dc,Dp,Tp}
     return KDTree(static_nodes)
 end
 
+function KDTree(node_coordinates::AbstractVector{<:Point2D})
+    T = eltype(first(node_coordinates))
+    static_nodes = convert.(SVector{2,T}, node_coordinates)
+    return KDTree(static_nodes)
+end
+
 """
     bounding_box(grid::UnstructuredGrid{Dc,Dp,Tp}) -> Tuple{Point2D{Tp}, Point2D{Tp}}
 
@@ -200,21 +216,23 @@ The bounding box is computed by finding the minimum and maximum coordinates acro
 nodes in each spatial dimension.
 """
 function bounding_box(grid::UnstructuredGrid{Dc,Dp,Tp}) where {Dc,Dp,Tp}
-    nodes = get_node_coordinates(grid)
+    return bounding_box(materialize_node_coordinates(grid))
+end
 
-    xmin = MVector{Dp,Tp}(Tuple(first(nodes)))
-    xmax = MVector{Dp,Tp}(Tuple(first(nodes)))
+function bounding_box(nodes::AbstractVector{Point2D{T}}) where {T}
+    xmin = MVector{2,T}(Tuple(first(nodes)))
+    xmax = MVector{2,T}(Tuple(first(nodes)))
 
     for node in nodes
-        for i in 1:Dp
+        for i in 1:2
             xi = node[i]
             xmin[i] = min(xmin[i], xi)
             xmax[i] = max(xmax[i], xi)
         end
     end
 
-    bb_min = convert(Point2D{Tp}, xmin)
-    bb_max = convert(Point2D{Tp}, xmax)
+    bb_min = convert(Point2D{T}, xmin)
+    bb_max = convert(Point2D{T}, xmax)
 
     return bb_min, bb_max
 end
@@ -261,8 +279,7 @@ function point_in_element(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Poin
 end
 
 function ordered_node_ids(mesh::Mesh, node_ids::AbstractVector{<:Integer})
-    node_coordinates = get_node_coordinates(get_grid(mesh.model))
-    return ordered_node_ids(node_coordinates, node_ids)
+    return ordered_node_ids(mesh.node_coordinates, node_ids)
 end
 
 function ordered_node_ids(node_coordinates, node_ids::AbstractVector{<:Integer})
@@ -507,8 +524,7 @@ The point is:
 - [`find_element`](@ref): Find which element contains a point
 """
 function point_in_triangle(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Point2D)
-    @unpack model = mesh
-    node_coordinates = get_node_coordinates(get_grid(model))
+    @unpack node_coordinates = mesh
 
     x1, y1 = node_coordinates[node_ids[1]]
     x2, y2 = node_coordinates[node_ids[2]]

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1,5 +1,5 @@
 """
-    Mesh{M,K,N,C,B}
+    Mesh{M,K,NC,T}
 
 A computational mesh structure that holds geometric and topological information essential
 for ray tracing algorithms in neutron transport simulations.
@@ -8,9 +8,8 @@ for ray tracing algorithms in neutron transport simulations.
 
 - `M`: Type of the underlying geometric model
 - `K`: Type of the spatial index structure (typically a KD-tree)
-- `N`: Type of the node-to-cells mapping
-- `C`: Type of the cell-to-nodes mapping
-- `B`: Type of the bounding box coordinates
+- `NC`: Type of the materialized connectivity mappings
+- `T`: Type of the bounding box coordinates
 
 ## Fields
 
@@ -19,8 +18,9 @@ for ray tracing algorithms in neutron transport simulations.
   queries
 - `node_cells::N`: Materialized mapping from node indices to the set of cells containing
   each node
-- `cell_nodes::C`: Materialized mapping from cell indices to the ordered list of node
-  indices defining each cell
+- `cell_nodes::C`: Materialized mapping from cell indices to the node indices defining each
+  cell
+- `ordered_cell_nodes::C`: Cell-node mapping ordered geometrically around each cell
 - `bb_min::B`: Minimum coordinates of the mesh bounding box (lower-left corner)
 - `bb_max::B`: Maximum coordinates of the mesh bounding box (upper-right corner)
 
@@ -81,6 +81,7 @@ struct Mesh{M<:UnstructuredDiscreteModel,K<:KDTree,NC,T}
     kdtree::K
     node_cells::NC
     cell_nodes::NC
+    ordered_cell_nodes::NC
     bb_min::Point2D{T}
     bb_max::Point2D{T}
 end
@@ -146,12 +147,18 @@ function Mesh(model::UnstructuredDiscreteModel)
         get_faces(get_grid_topology(model), 0, num_cell_dims(model))
     )
     cell_nodes = materialize_connectivity(get_cell_node_ids(grid))
+    ordered_cell_nodes = materialize_ordered_cell_nodes(grid, cell_nodes)
     bb_min, bb_max = bounding_box(grid)
-    return Mesh(model, kdtree, node_cells, cell_nodes, bb_min, bb_max)
+    return Mesh(model, kdtree, node_cells, cell_nodes, ordered_cell_nodes, bb_min, bb_max)
 end
 
 function materialize_connectivity(connectivity)
     return [Vector{Int32}(ids) for ids in connectivity]
+end
+
+function materialize_ordered_cell_nodes(grid, cell_nodes)
+    node_coordinates = get_node_coordinates(grid)
+    return [Vector{Int32}(ordered_node_ids(node_coordinates, node_ids)) for node_ids in cell_nodes]
 end
 
 """
@@ -254,9 +261,13 @@ function point_in_element(mesh::Mesh, node_ids::AbstractVector{<:Int32}, x::Poin
 end
 
 function ordered_node_ids(mesh::Mesh, node_ids::AbstractVector{<:Integer})
+    node_coordinates = get_node_coordinates(get_grid(mesh.model))
+    return ordered_node_ids(node_coordinates, node_ids)
+end
+
+function ordered_node_ids(node_coordinates, node_ids::AbstractVector{<:Integer})
     length(node_ids) <= 3 && return node_ids
 
-    node_coordinates = get_node_coordinates(get_grid(mesh.model))
     T = eltype(first(node_coordinates))
     cx = zero(T)
     cy = zero(T)

--- a/src/plot_recipes.jl
+++ b/src/plot_recipes.jl
@@ -116,10 +116,7 @@ end
 end
 
 @recipe function plot(mesh::Mesh)
-    @unpack cell_nodes, model = mesh
-
-    grid = get_grid(model)
-    nodes = get_node_coordinates(grid)
+    @unpack cell_nodes, node_coordinates = mesh
 
     n_cells = length(cell_nodes)
     max_nodes = maximum(length, cell_nodes)
@@ -132,11 +129,11 @@ end
     for (i, node_ids) in enumerate(cell_nodes)
         ids = ordered_node_ids(mesh, node_ids)
         for (j, node_id) in enumerate(ids)
-            x[j, i] = nodes[node_id][1]
-            y[j, i] = nodes[node_id][2]
+            x[j, i] = node_coordinates[node_id][1]
+            y[j, i] = node_coordinates[node_id][2]
         end
-        x[length(ids)+1, i] = nodes[first(ids)][1]
-        y[length(ids)+1, i] = nodes[first(ids)][2]
+        x[length(ids)+1, i] = node_coordinates[first(ids)][1]
+        y[length(ids)+1, i] = node_coordinates[first(ids)][2]
     end
 
     seriestype := :path

--- a/src/segment.jl
+++ b/src/segment.jl
@@ -11,7 +11,6 @@ of transport equations over individual mesh cells.
 - `p::Point2D{T}`: Entry point where the track enters the mesh element
 - `q::Point2D{T}`: Exit point where the track exits the mesh element
 - `ℓ::T`: Length of the segment within the element
-- `τ::Vector{T}`: Storage for transport-related data (e.g., optical thickness)
 - `element::Int32`: ID of the mesh element containing this segment
 
 ## Usage
@@ -24,12 +23,11 @@ struct Segment{T<:Real}
     p::Point2D{T}
     q::Point2D{T}
     ℓ::T
-    τ::Vector{T}
     element::Int32
 end
 
 function Segment(p::Point2D{T}, q::Point2D{T}, element::Int32=Int32(-1)) where {T}
-    return Segment(p, q, norm(p - q), Vector{T}(), element)
+    return Segment(p, q, norm(p - q), element)
 end
 
 ℓ(segment::Segment) = segment.ℓ

--- a/src/segment.jl
+++ b/src/segment.jl
@@ -36,9 +36,21 @@ end
 
 in(x::Point2D, segment::Segment) = point_in_segment(segment.p, segment.q, x)
 
-function point_in_segment(p::Point2D, q::Point2D, x::Point2D)
-    lpx = norm(p - x)
-    lqx = norm(q - x)
-    lpq = norm(p - q)
-    return isapprox(lpx + lqx, lpq)
+@inline function point_in_segment(p::Point2D, q::Point2D, x::Point2D)
+    dx = q[1] - p[1]
+    dy = q[2] - p[2]
+    px = x[1] - p[1]
+    py = x[2] - p[2]
+
+    T = promote_type(eltype(p), eltype(q), eltype(x))
+    scale = max(abs(dx), abs(dy), one(T))
+    rtol = Base.rtoldefault(T)
+
+    cross = dx * py - dy * px
+    abs(cross) <= rtol * scale^2 || return false
+
+    xmin, xmax = minmax(p[1], q[1])
+    ymin, ymax = minmax(p[2], q[2])
+    atol = rtol * scale
+    return xmin - atol <= x[1] <= xmax + atol && ymin - atol <= x[2] <= ymax + atol
 end

--- a/src/track.jl
+++ b/src/track.jl
@@ -121,26 +121,25 @@ function show(io::IO, track::Track)
     println(io, "  Entry point: ", p)
     println(io, "  Exit point: ", q)
     println(io, "  Length: ", ℓ)
-    println(io, "  # of segments: ", length(segments)) # if it is zero, run segmentize!
+    println(io, "  # of segments: ", length(segments)) # Run segmentize! if this is zero.
     println(io, "  Boundary fwd: ", bc_fwd(track))
     print(io, "  Boundary bwd: ", bc_bwd(track))
-    # avoid printing circular references (since it is a cyclic ray tracing...)
+    # Avoid printing circular references from cyclic ray tracing.
     # println(io, "  Next track fwd: ", next_track_fwd)
     # print(io,   "  Next track fwd: ", next_track_bwd)
 end
 
-# since we are in active development of the package and there might be unconsidered cases in
-# the segmentation of tracks, let's have this maximum number of iterations.
+# Keep a hard iteration cap while track segmentation edge cases are still being refined.
 const MAX_ITER = 10_000
 
-function _segmentize_track!(t, track::Track, k::Int, rtol::Real) # t::TrackGenerator
+function _segmentize_track!(t, track::Track, k::Int, rtol::Real) # `t` is a TrackGenerator.
     @unpack mesh, tiny_step = t
     @unpack ϕ, segments = track
 
-    # since we are going to compute them, empty!
+    # Clear any existing segments before recomputing them.
     empty!(segments)
 
-    # move a tiny step in ϕ direction to get inside the mesh
+    # Move a tiny step along ϕ to enter the mesh interior.
     xp = advance_step(track.p, tiny_step, ϕ)
 
     i = 0
@@ -148,23 +147,23 @@ function _segmentize_track!(t, track::Track, k::Int, rtol::Real) # t::TrackGener
     prev_element = -1
     while i < MAX_ITER
 
-        # find the element or cell where `xp` lies
+        # Find the element containing `xp`.
         element = find_element(mesh, xp)
 
-        # we might be at the boundary of the mesh
+        # `xp` may lie on the mesh boundary.
         if on_boundary(mesh, xp, tiny_step)
             if isempty(segments)
-                # if we just started to segmentize, move a tiny step forward
+                # If segmentation just started, move a tiny step forward.
                 xp = advance_step(xp, tiny_step, ϕ)
                 continue
             else
-                # or we just finished, so leave
+                # Otherwise, segmentation has reached the boundary and is done.
                 break
             end
         end
 
-        # if we are inside the domain and `find_element` did not return an element, we might
-        # be dealing with a deformed mesh, so we might need to increase the knn search.
+        # If `find_element` fails inside the domain, a deformed mesh may require a wider
+        # nearest-neighbor search.
         if isequal(element, -1)
             element = find_element(mesh, xp, k)
             if isequal(element, -1)
@@ -173,16 +172,16 @@ function _segmentize_track!(t, track::Track, k::Int, rtol::Real) # t::TrackGener
             end
         end
 
-        # move a step if the new element is the same as the previous one
+        # Step forward if the new element matches the previous one.
         if isequal(prev_element, element)
             xp = advance_step(xp, tiny_step, ϕ)
             continue
         end
 
-        # compute intersections between track and the element
+        # Compute intersections between the track and the element.
         p, q = intersections(mesh, element, track)
 
-        # we might be in a vertex, so we just continue
+        # A vertex hit can produce a zero-length segment; skip it and move forward.
         if isapprox(p, q)
             xp = advance_step(xp, tiny_step, ϕ)
             continue
@@ -191,11 +190,11 @@ function _segmentize_track!(t, track::Track, k::Int, rtol::Real) # t::TrackGener
         segment = Segment(p, q, element)
         push!(segments, segment)
 
-        # update new starting point and previous element
+        # Update the next starting point and previous element.
         xp = advance_step(q, tiny_step, ϕ)
         prev_element = element
 
-        i += 1 # just for safety
+        i += 1 # Safety counter.
     end
 
     if !isapprox(track.ℓ, sum(ℓ.(track.segments)); rtol=rtol)

--- a/src/trackgenerator.jl
+++ b/src/trackgenerator.jl
@@ -370,11 +370,7 @@ function fill_volumes(t::TrackGenerator{T}) where {T}
     fill!(volumes, zero(T))
 
     for track in tracks_by_uid
-        a = track.azim_idx
-        for segment in track.segments
-            i = segment.element
-            volumes[i] += δs[a] * segment.ℓ
-        end
+        accumulate_track_volume!(volumes, δs, track)
     end
 
     volumes ./= n_azim_2
@@ -385,6 +381,14 @@ function fill_volumes(t::TrackGenerator{T}) where {T}
         end
     end
 
+    return nothing
+end
+
+function accumulate_track_volume!(volumes, δs, track::Track)
+    δ = δs[track.azim_idx]
+    for segment in track.segments
+        volumes[segment.element] += δ * segment.ℓ
+    end
     return nothing
 end
 

--- a/src/trackgenerator.jl
+++ b/src/trackgenerator.jl
@@ -380,9 +380,8 @@ function fill_volumes(t::TrackGenerator{T}) where {T}
     volumes ./= n_azim_2
 
     if volume_correction
-        @unpack cell_nodes = mesh
         for i in eachindex(volumes)
-            volumes[i] = element_volume(mesh, cell_nodes[i])
+            volumes[i] = element_volume(mesh, i)
         end
     end
 
@@ -393,7 +392,16 @@ function element_volume(mesh, node_ids)
     @unpack model = mesh
     node_coordinates = get_node_coordinates(get_grid(model))
     ordered_ids = ordered_node_ids(mesh, node_ids)
+    return _element_volume_from_ordered_nodes(node_coordinates, ordered_ids)
+end
 
+function element_volume(mesh::Mesh, cell_id::Integer)
+    @unpack model, ordered_cell_nodes = mesh
+    node_coordinates = get_node_coordinates(get_grid(model))
+    return _element_volume_from_ordered_nodes(node_coordinates, ordered_cell_nodes[cell_id])
+end
+
+function _element_volume_from_ordered_nodes(node_coordinates, ordered_ids)
     area = zero(eltype(first(node_coordinates)))
     for i in eachindex(ordered_ids)
         j = i == lastindex(ordered_ids) ? firstindex(ordered_ids) : i + 1

--- a/src/trackgenerator.jl
+++ b/src/trackgenerator.jl
@@ -21,10 +21,10 @@ iterative transport sweeps.
 
 ## Usage
 ```julia
-# Create track generator
+# Create a track generator.
 tg = TrackGenerator(model, 16, 0.08, bcs=BoundaryConditions(top=Reflective, ...))
 
-# Generate tracks and segments
+# Generate tracks and segments.
 trace!(tg)
 segmentize!(tg)
 ```
@@ -71,11 +71,10 @@ origins_in_y(n_tracks_x, i, j) = !origins_in_x(n_tracks_x, i, j)
         tiny_step::T=1e-8, volume_correction=false
     ) where {T<:Real}
 
-Initialize a [`TrackGenerator`](@ref) using an [`UnstructuredDiscreteModel`](@ref) which holds mesh
-related information, the number of azimuthal angles `n_azim` and the azimuthal spacing `δ`. The
-optional attributes are `tiny_step`, which is used in the track's segmentation routine, and
-`volume_correction`, which allows for cell volume correction since the ray tracing algorithm yields
-to approximate volumes.
+Initialize a [`TrackGenerator`](@ref) using an [`UnstructuredDiscreteModel`](@ref), the number
+of azimuthal angles `n_azim`, and the azimuthal spacing `δ`. The optional attributes are
+`tiny_step`, which is used in track segmentation, and `volume_correction`, which corrects cell
+volumes because ray tracing produces approximate volumes.
 """
 function TrackGenerator(
     model::UnstructuredDiscreteModel, n_azim::Int, δ::T;
@@ -99,7 +98,7 @@ function TrackGenerator(
         n_tracks_y[i] = floor(Δy / δ * abs(cos(φ))) + 1
         n_tracks[i] = n_tracks_x[i] + n_tracks_y[i]
 
-        # suplementary angles:
+        # Supplementary angles:
         j = supplementary_azimuthal_idx(azimuthal_quadrature, i)
         n_tracks_x[j] = n_tracks_x[i]
         n_tracks_y[j] = n_tracks_y[i]
@@ -138,7 +137,7 @@ function trace!(t::TrackGenerator{T}) where {T}
 
     n_azim_2 = n_azim_half(azimuthal_quadrature)
 
-    # effective azimuthal spacings, used for some computations but not stored
+    # Effective azimuthal spacings used for intermediate computations.
     δx = Vector{T}(undef, n_azim_2)
     δy = Vector{T}(undef, n_azim_2)
 
@@ -146,15 +145,15 @@ function trace!(t::TrackGenerator{T}) where {T}
 
     for i in azimuthal_quadrant_1(azimuthal_quadrature)
 
-        # effective azimuthal angle
+        # Effective azimuthal angle.
         ϕ = ϕs[i] = atan((Δy * n_tracks_x[i]) / (Δx * n_tracks_y[i]))
 
-        # effective azimuthal spacings
+        # Effective azimuthal spacings.
         δx[i] = Δx / n_tracks_x[i]
         δy[i] = Δy / n_tracks_y[i]
         δs[i] = δx[i] * sin(ϕ)
 
-        # suplementary angles:
+        # Supplementary angles:
         j = supplementary_azimuthal_idx(azimuthal_quadrature, i)
         ϕs[j] = π - ϕ
         δx[j] = δx[i]
@@ -162,10 +161,10 @@ function trace!(t::TrackGenerator{T}) where {T}
         δs[j] = δs[i]
     end
 
-    # once we have computed all the azimuthal angles, compute weights
+    # Compute weights after all azimuthal angles are available.
     init_weights!(azimuthal_quadrature)
 
-    # mesh vertices and boundary segments
+    # Mesh vertices and boundary segments.
     p1 = bb_min
     p2 = Point2D(bb_min[1], bb_max[2])
     p3 = bb_max
@@ -175,10 +174,10 @@ function trace!(t::TrackGenerator{T}) where {T}
     uid = 1
     for i in azimuthal_half_plane(azimuthal_quadrature)
 
-        # get azimuthal angle
+        # Get the azimuthal angle.
         ϕ = ϕs[i]
 
-        # for all tracks in a given azimuthal direction `i`
+        # Iterate over all tracks in azimuthal direction `i`.
         for j in 1:n_tracks[i]
 
             if origins_in_x(n_tracks_x, i, j)
@@ -195,19 +194,19 @@ function trace!(t::TrackGenerator{T}) where {T}
                 end
             end
 
-            # it can exit at y = Δy regardless if it points to the right or left
+            # The track can exit at y = Δy whether it points right or left.
             m = tan(ϕ)
             q = Point2D(p[1] - (p[2] - Δy) / m, Δy)
 
-            # keep going if `q` is not an exit point
+            # Continue searching if `q` is not a valid exit point.
             if !(0 ≤ q[1] ≤ Δx)
 
-                # it can exit at x = Δx if it points to the right
+                # A rightward track can exit at x = Δx.
                 if is_rightward_direction(azimuthal_quadrature, i)
                     q = Point2D(Δx, p[2] + m * (Δx - p[1]))
 
                 else
-                    # or it can exit at x = 0 if it points to the left
+                    # A leftward track can exit at x = 0.
                     q = Point2D(0, p[2] - m * p[1])
                 end
 
@@ -216,7 +215,7 @@ function trace!(t::TrackGenerator{T}) where {T}
                 end
             end
 
-            # recalibrate coordinates and compute distance
+            # Shift coordinates into the mesh frame and compute distance.
             p += bb_min
             q += bb_min
             ℓ = norm(p - q)
@@ -227,7 +226,7 @@ function trace!(t::TrackGenerator{T}) where {T}
             BCFwd = get_boundary_condition_at(q, boundary, bcs)
             BCBwd = get_boundary_condition_at(p, boundary, bcs)
 
-            # alternative method
+            # Cross-check boundary conditions using track indices.
             if is_rightward_direction(azimuthal_quadrature, i)
                 BCFwd1 = j ≤ n_tracks_y[i] ? bcs.right : bcs.top
                 BCBwd1 = j ≤ n_tracks_x[i] ? bcs.bottom : bcs.left
@@ -269,7 +268,7 @@ function trace!(t::TrackGenerator{T}) where {T}
         end
     end
 
-    # once we have all tracks and boundary conditions, set next tracks
+    # Set next-track links after all tracks and boundary conditions are known.
     next_tracks(t)
 
     return t
@@ -278,7 +277,7 @@ end
 function next_tracks(t::TrackGenerator)
     @unpack tracks_by_uid = t
 
-    # search for the next track in forward and backward direction
+    # Search for next tracks in the forward and backward directions.
     for track in tracks_by_uid
         next_track_fwd(t, track)
         next_track_bwd(t, track)
@@ -296,7 +295,7 @@ function next_track_fwd(t::TrackGenerator, track::Track)
 
     BCFwd = bc_fwd(track)
 
-    # these are the tracks that arrive to the y-axis
+    # Tracks that arrive at the y-axis.
     if j ≤ n_tracks_y[i]
         if BCFwd == Periodic
             track.next_track_fwd = tracks[i][j+n_tracks_x[i]]
@@ -304,7 +303,7 @@ function next_track_fwd(t::TrackGenerator, track::Track)
             track.next_track_fwd = tracks[k][j+n_tracks_x[i]]
         end
     else
-        # these are the tracks that arrive to the top (superior x-axis)
+        # Tracks that arrive at the top edge.
         if BCFwd == Periodic
             track.next_track_fwd = tracks[i][j-n_tracks_y[i]]
         elseif is_vacuum(BCFwd) || is_reflective(BCFwd)
@@ -324,14 +323,14 @@ function next_track_bwd(t::TrackGenerator, track::Track)
 
     BCBwd = bc_bwd(track)
 
-    # these are the tracks that arrive to the bottom (inferior x-axis)
+    # Tracks that arrive at the bottom edge.
     if j ≤ n_tracks_x[i]
         if is_periodic(BCBwd)
             track.next_track_bwd = tracks[i][j+n_tracks_y[i]]
         elseif is_vacuum(BCBwd) || is_reflective(BCBwd)
             track.next_track_bwd = tracks[k][n_tracks_x[i]-j+1]
         end
-        # these are the tracks that arrive to the y-axis
+        # Tracks that arrive at the y-axis.
     else
         if is_periodic(BCBwd)
             track.next_track_bwd = tracks[i][j-n_tracks_x[i]]
@@ -346,9 +345,8 @@ end
 """
     segmentize!(t::TrackGenerator)
 
-Segmentize tracks, i.e. divide the tracks in segments generated by the intersections
-between the cells or elements of the mesh. This function call is intended to be done after
-calling `[trace!]`(@ref).
+Split tracks into segments generated by intersections with mesh cells/elements. Call this
+after [`trace!`](@ref).
 """
 function segmentize!(t::TrackGenerator{T}; k::Int=5, rtol::Real=Base.rtoldefault(T)) where {T}
     @unpack tracks_by_uid = t

--- a/src/trackgenerator.jl
+++ b/src/trackgenerator.jl
@@ -389,15 +389,13 @@ function fill_volumes(t::TrackGenerator{T}) where {T}
 end
 
 function element_volume(mesh, node_ids)
-    @unpack model = mesh
-    node_coordinates = get_node_coordinates(get_grid(model))
+    @unpack node_coordinates = mesh
     ordered_ids = ordered_node_ids(mesh, node_ids)
     return _element_volume_from_ordered_nodes(node_coordinates, ordered_ids)
 end
 
 function element_volume(mesh::Mesh, cell_id::Integer)
-    @unpack model, ordered_cell_nodes = mesh
-    node_coordinates = get_node_coordinates(get_grid(model))
+    @unpack node_coordinates, ordered_cell_nodes = mesh
     return _element_volume_from_ordered_nodes(node_coordinates, ordered_cell_nodes[cell_id])
 end
 

--- a/test/bwr-gmsh.jl
+++ b/test/bwr-gmsh.jl
@@ -4,12 +4,12 @@ using GridapGmsh: gmsh, GmshDiscreteModel
 function add_pin!(gmsh, o, r, t, lc)
     factory = gmsh.model.geo
 
-    # inner and outer circle
+    # Inner and outer circles.
     l1 = add_circle!(gmsh, o, r, lc)
     l2 = add_circle!(gmsh, o, r + t, lc)
 
     s1 = factory.addPlaneSurface([l1])
-    s2 = factory.addPlaneSurface([l2, l1]) # l1 is a hole
+    s2 = factory.addPlaneSurface([l2, l1]) # l1 is a hole.
 
     return s1, s2
 end
@@ -18,11 +18,11 @@ function add_circle!(gmsh, o, r, lc)
     factory = gmsh.model.geo
     ox, oy = o
 
-    p1 = factory.addPoint(ox, oy, 0, lc)  # center - origin
-    p2 = factory.addPoint(ox + r, oy, 0, lc)  # right
-    p3 = factory.addPoint(ox, oy + r, 0, lc)  # up
-    p4 = factory.addPoint(ox - r, oy, 0, lc)  # left
-    p5 = factory.addPoint(ox, oy - r, 0, lc)  # down
+    p1 = factory.addPoint(ox, oy, 0, lc)  # Center/origin.
+    p2 = factory.addPoint(ox + r, oy, 0, lc)  # Right.
+    p3 = factory.addPoint(ox, oy + r, 0, lc)  # Up.
+    p4 = factory.addPoint(ox - r, oy, 0, lc)  # Left.
+    p5 = factory.addPoint(ox, oy - r, 0, lc)  # Down.
 
     c1 = factory.addCircleArc(p2, p1, p3)
     c2 = factory.addCircleArc(p3, p1, p4)
@@ -54,22 +54,22 @@ end
 
 N = 4
 
-# in cm
-p = 1.6        # pitch
-ri = 0.5       # internal radius
-t = 0.1        # wall thickness
-ro = ri + t    # external radius
+# Dimensions in cm.
+p = 1.6        # Pitch.
+ri = 0.5       # Inner radius.
+t = 0.1        # Wall thickness.
+ro = ri + t    # Outer radius.
 lc = 0.1
 
 gmsh.initialize()
 gmsh.model.add("bwr")
 
-# tags
+# Physical group tags.
 pinTags = Int32[]
 cladTags = Int32[]
 gdPinTags = Int32[]
 
-# gd pins positions
+# Gd pin positions.
 GD_pos = [(2, 3), (3, 2)]
 
 for i in 1:N, j in 1:N
@@ -85,7 +85,7 @@ for i in 1:N, j in 1:N
     end
 end
 
-#! TODO: h2oTag = add_reflector!(gmsh, 4p)
+#! TODO: Add a reflector surface with h2oTag = add_reflector!(gmsh, 4p).
 s = N * p
 factory = gmsh.model.geo
 
@@ -121,7 +121,7 @@ gmsh.model.setPhysicalName(1, pg6, "right")
 gmsh.model.setPhysicalName(1, pg7, "top")
 gmsh.model.setPhysicalName(1, pg8, "left")
 
-# removemos puntos de la geometria duplicados (origenes por ejemplo)
+# Remove duplicate geometry points, such as coincident origins.
 gmsh.model.geo.removeAllDuplicates()
 
 gmsh.model.geo.synchronize()
@@ -144,20 +144,20 @@ Gridap.Io.to_json_file(model, "bwr.json")
 jsonfile = joinpath(@__DIR__,"../bwr.json")
 model = DiscreteModelFromFile(jsonfile)
 
-# number of azimuthal angles
+# Number of azimuthal angles.
 nφ = 16
 
-# azimuthal spacing
+# Azimuthal spacing.
 δ = 0.002
 
-# boundary conditions
+# Boundary conditions.
 bcs = BoundaryConditions(top=Reflective, bottom=Reflective, left=Reflective, right=Reflective)
 
-# initialize track generator
+# Initialize the track generator.
 tg = TrackGenerator(model, nφ, δ, bcs=bcs)
 
-# perform ray tracing
+# Perform ray tracing.
 trace!(tg)
 
-# proceed to segmentation
+# Segment the tracks.
 segmentize!(tg)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,8 @@ model = DiscreteModelFromFile(jsonfile)
     @test quad_mesh.node_cells isa Vector{Vector{Int32}}
     @test quad_mesh.cell_nodes isa Vector{Vector{Int32}}
     @test quad_mesh.ordered_cell_nodes isa Vector{Vector{Int32}}
+    @test quad_mesh.node_coordinates isa Vector{RayTracing.Point2D{Float64}}
+    @test length(quad_mesh.node_coordinates) == RayTracing.num_nodes(quad_mesh)
     @test length(quad_mesh.ordered_cell_nodes) == length(quad_mesh.cell_nodes)
     @test RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(0.0, 0.0))
     @test !RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(2.0, 0.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,8 @@ model = DiscreteModelFromFile(jsonfile)
     quad_mesh = RayTracing.Mesh(quad_model)
     quad_node_ids = quad_mesh.cell_nodes[1]
 
+    @test quad_mesh.node_cells isa Vector{Vector{Int32}}
+    @test quad_mesh.cell_nodes isa Vector{Vector{Int32}}
     @test RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(0.0, 0.0))
     @test !RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(2.0, 0.0))
     @test RayTracing.element_volume(quad_mesh, quad_node_ids) ≈ 4.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,7 +189,7 @@ end
         @test DirNextTrackBwd == RayTracing.Backward
     end
 
-    # a more complicated case
+    # A more complicated case.
     tg = TrackGenerator(model, 8, 0.8; bcs=bcs)
     trace!(tg)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,9 +25,12 @@ model = DiscreteModelFromFile(jsonfile)
 
     @test quad_mesh.node_cells isa Vector{Vector{Int32}}
     @test quad_mesh.cell_nodes isa Vector{Vector{Int32}}
+    @test quad_mesh.ordered_cell_nodes isa Vector{Vector{Int32}}
+    @test length(quad_mesh.ordered_cell_nodes) == length(quad_mesh.cell_nodes)
     @test RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(0.0, 0.0))
     @test !RayTracing.point_in_element(quad_mesh, quad_node_ids, RayTracing.Point2D(2.0, 0.0))
     @test RayTracing.element_volume(quad_mesh, quad_node_ids) ≈ 4.0
+    @test RayTracing.element_volume(quad_mesh, 1) ≈ 4.0
 
     tg = TrackGenerator(quad_model, 4, 0.7; bcs=reflective_boundaries(), volume_correction=true)
     trace!(tg)


### PR DESCRIPTION
## Summary

- Materialize mesh connectivity and cache ordered cell nodes plus node coordinates.
- Remove repeated Gridap coordinate/connectivity lookups from intersection, volume, and plotting paths.
- Make element-volume lookup use cached ordered nodes.
- Remove per-intersection heap allocation and the now-unused Combinatorics dependency.
- Slim Segment storage by removing unused tau storage.
- Add a function barrier for volume accumulation to specialize per concrete track type.

## Performance

Benchmarked against origin/codex/english-comment-polish on the same selected benchmark slice:

| Benchmark | Before | After | Impact |
|---|---:|---:|---:|
| find_element | 583 ns, 30 allocs | 292 ns, 0 allocs | ~2x faster |
| intersection/track_cell | 167 ns, 10 allocs | 125 ns, 0 allocs | faster, alloc-free |
| element_volume_batch | 73.96 us, 9216 allocs | 5.46 us, 0 allocs | ~13.5x faster |
| coarse segmentize! | 2.142 ms, 7.10 MiB | 1.189 ms, 281 KiB | ~44% faster |
| moderate segmentize! | 7.900 ms, 26.13 MiB | 4.184 ms, 984 KiB | ~47% faster |
| moderate trace+segmentize! | 8.420 ms, 26.58 MiB | 4.721 ms, 1.25 MiB | ~44% faster |
| volume correction | 8.302 ms, 28.34 MiB | 4.249 ms, 984 KiB | ~49% faster |

Tradeoff: Mesh(model) construction now does more eager cache construction, so construction is slower (34.9 us -> 473.9 us) and allocates more. The intended payoff is faster repeated tracing/segmentation and geometry queries.

## Breaking Change

- Removed Segment.tau/Segment.τ. It was an eagerly allocated empty vector per segment, and neither RayTracing docs/README nor local NeutronTransport usage referenced it.

## Validation

- RayTracing: Pkg.test() passes.
- RayTracing: git diff --check passes.
- NeutronTransport: Pkg.test() passes against local ../RayTracing.jl (current suite reports 0 tests).
- Generated Manifest.toml files were removed before pushing.