### PR TITLE
fix: correct azimuthal quadrature weights

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RayTracing"
 uuid = "3007c720-8091-40db-9339-e09e4eb4c7ea"
 authors = ["Ramiro Vignolo <ramirovignolo@gmail.com>"]
-version = "0.2.4"
+version = "0.3.0"
 
 [deps]
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"

--- a/src/azimuthal_quad.jl
+++ b/src/azimuthal_quad.jl
@@ -58,7 +58,7 @@ supp_idx = supplementary_azimuthal_idx(aq, 1)  # 4
 The weights `ωₐ` are computed to ensure proper numerical integration:
 
 ```julia
-# The sum of weights should integrate to unity.
+# The sum of weights covers the azimuthal half-plane represented by tracks.
 sum(aq.ωₐ) ≈ 0.5  # Over the half-plane (0, π).
 ```
 
@@ -276,11 +276,12 @@ spacing between adjacent azimuthal angles.
 
 ## Weight Calculation
 
-For each azimuthal angle index `i` in the first quadrant:
+For each azimuthal angle index `i` in the first quadrant, the weight is the angular
+bin width divided by `2π`:
 
-- **First angle (i=1)**: `ωₐ[i] = (ϕs[i+1] - ϕs[i]) / (4π)`
-- **Last angle (i=N4)**: `ωₐ[i] = (π - ϕs[i] - ϕs[i-1]) / (4π)`
-- **Middle angles**: `ωₐ[i] = (ϕs[i+1] - ϕs[i-1]) / (4π)`
+- **Lower edge**: `0` for the first angle, otherwise `(ϕs[i-1] + ϕs[i]) / 2`
+- **Upper edge**: `π/2` for the last angle, otherwise `(ϕs[i] + ϕs[i+1]) / 2`
+- **Weight**: `ωₐ[i] = (upper - lower) / (2π)`
 
 The weights are then copied to the supplementary angles using the relationship `ωₐ[j] =
 ωₐ[i]` where `j = supplementary_azimuthal_idx(aq, i)`.
@@ -294,9 +295,8 @@ The weights are then copied to the supplementary angles using the relationship `
 ## Mathematical Background
 
 The weights represent the angular measure associated with each azimuthal direction,
-normalized by `4π` to ensure proper integration over the full solid angle. This
-normalization accounts for the fact that we're working in 2D (azimuthal angles only) but the
-weights should integrate to unity over the full angular domain.
+normalized by `2π`. Tracks explicitly cover the azimuthal half-plane `(0, π)`, so
+`sum(ωₐ)` over the stored half-plane is `1/2`.
 
 ## Example
 ```julia
@@ -309,17 +309,13 @@ init_weights!(aq)
 function init_weights!(aq::AzimuthalQuadrature)
     @unpack ϕs, ωₐ = aq
     n_azim_4 = n_azim_quad(aq)
-    inv_4π = inv(4π)
+    inv_2π = inv(2π)
 
     for i in 1:n_azim_4
-        if isone(i)
-            ωₐ[i] = ϕs[i+1] - ϕs[i]
-        elseif isequal(i, n_azim_4)
-            ωₐ[i] = π - ϕs[i] - ϕs[i-1]
-        else
-            ωₐ[i] = ϕs[i+1] - ϕs[i-1]
-        end
-        ωₐ[i] *= inv_4π
+        lower = isone(i) ? zero(eltype(ϕs)) : (ϕs[i-1] + ϕs[i]) / 2
+        upper = isequal(i, n_azim_4) ? oftype(ϕs[i], π / 2) :
+                (ϕs[i] + ϕs[i+1]) / 2
+        ωₐ[i] = (upper - lower) * inv_2π
         ωₐ[supplementary_azimuthal_idx(aq, i)] = ωₐ[i]
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,12 +100,26 @@ end
     end
 
     @testset "Azimuthal quadrature" begin
-        @test isequal(RayTracing.n_azim_total(tg.azimuthal_quadrature), 8)
-        @test isequal(RayTracing.n_azim_half(tg.azimuthal_quadrature), 4)
-        @test isequal(RayTracing.n_azim_quad(tg.azimuthal_quadrature), 2)
-        @test isapprox(tg.azimuthal_quadrature.δ, 0.02)
-        @test all(isapprox.(tg.azimuthal_quadrature.δs, 0.01994243696980254))
-        @test tg.azimuthal_quadrature.ϕs ≈ [0.39670866289121387, 1.1740876639036828, 1.9675049896861103, 2.7448839906985794]
+        aq = tg.azimuthal_quadrature
+
+        @test isequal(RayTracing.n_azim_total(aq), 8)
+        @test isequal(RayTracing.n_azim_half(aq), 4)
+        @test isequal(RayTracing.n_azim_quad(aq), 2)
+        @test isapprox(aq.δ, 0.02)
+        @test all(isapprox.(aq.δs, 0.01994243696980254))
+        @test aq.ϕs ≈ [0.39670866289121387, 1.1740876639036828, 1.9675049896861103, 2.7448839906985794]
+        @test sum(aq.ωₐ) ≈ 0.5
+        @test aq.ωₐ[1] ≈ (aq.ϕs[1] + aq.ϕs[2]) / (4π)
+        @test aq.ωₐ[2] ≈ (π - aq.ϕs[1] - aq.ϕs[2]) / (4π)
+        @test aq.ωₐ[3] ≈ aq.ωₐ[2]
+        @test aq.ωₐ[4] ≈ aq.ωₐ[1]
+
+        tg4 = TrackGenerator(model, 4, 0.02)
+        trace!(tg4)
+        aq4 = tg4.azimuthal_quadrature
+        @test RayTracing.n_azim_quad(aq4) == 1
+        @test aq4.ωₐ ≈ [0.25, 0.25]
+        @test sum(aq4.ωₐ) ≈ 0.5
     end
 
     @testset "Entry and exit points" begin


### PR DESCRIPTION
## Summary
- compute azimuthal weights from angular bin widths normalized by 2π
- preserve the existing n_azim_* helper API
- add regression tests for half-plane weight normalization, supplementary symmetry, and the n_azim=4 edge case
- bump RayTracing to v0.3.0 for the breaking/correctness release

## Tests
- /Users/rvignolo/.julia/juliaup/julia-1.12.6+0.aarch64.apple.darwin14/Julia-1.12.app/Contents/Resources/julia/bin/julia --project=. -e 'using Pkg; Pkg.test()'